### PR TITLE
feat(inline, visual-select): scaffold UI and commands for visual selection tools

### DIFF
--- a/lua/ghostwrite/chat.lua
+++ b/lua/ghostwrite/chat.lua
@@ -1,3 +1,4 @@
+local config = require("ghostwrite.config").get()
 local Layout = require("nui.layout")
 local ChatOutput = require("ghostwrite.chat_output")
 local ChatToolbar = require("ghostwrite.chat_toolbar")
@@ -143,11 +144,11 @@ function M.open()
 	-- set shared keys for all popups
 	for _, pane in ipairs(panes) do
 		-- pane movement
-		pane.popup:map("n", "<Up>", focus_up, M.default_bind_opts)
-		pane.popup:map("n", "<Down>", focus_down, M.default_bind_opts)
-		pane.popup:map("n", "<Tab>", focus_up, M.default_bind_opts)
+		pane.popup:map("n", "<Up>", focus_up, config.default_bind_opts)
+		pane.popup:map("n", "<Down>", focus_down, config.default_bind_opts)
+		pane.popup:map("n", "<Tab>", focus_up, config.default_bind_opts)
 		-- exit
-		pane.popup:map("n", "<Esc>", close_panel, M.default_bind_opts)
+		pane.popup:map("n", "<Esc>", close_panel, config.default_bind_opts)
 	end
 end
 

--- a/lua/ghostwrite/chat_toolbar.lua
+++ b/lua/ghostwrite/chat_toolbar.lua
@@ -1,3 +1,4 @@
+local config = require("ghostwrite.config").get()
 local Popup = require("nui.popup")
 local M = {}
 
@@ -162,12 +163,12 @@ function M.on_focus(winid)
 		M.all_buttons[selected_button_index].action()
 	end
 
-	M.toolbar_popup:map("n", "<Left>", select_left, M.default_bind_opts)
-	M.toolbar_popup:map("n", "h", select_left, M.default_bind_opts)
-	M.toolbar_popup:map("n", "<Right>", select_right, M.default_bind_opts)
-	M.toolbar_popup:map("n", "l", select_right, M.default_bind_opts)
+	M.toolbar_popup:map("n", "<Left>", select_left, config.default_bind_opts)
+	M.toolbar_popup:map("n", "h", select_left, config.default_bind_opts)
+	M.toolbar_popup:map("n", "<Right>", select_right, config.default_bind_opts)
+	M.toolbar_popup:map("n", "l", select_right, config.default_bind_opts)
 
-	M.toolbar_popup:map("n", "<Cr>", select, M.default_bind_opts)
+	M.toolbar_popup:map("n", "<Cr>", select, config.default_bind_opts)
 end
 
 function M.on_unfocus()

--- a/lua/ghostwrite/config.lua
+++ b/lua/ghostwrite/config.lua
@@ -1,0 +1,23 @@
+local M = {}
+
+local defaults = {
+	default_bind_opts = { noremap = true, silent = true, nowait = true },
+	prompt_templates = {
+		summarize = "Summarize the following code:",
+		comment = "Add comments to this code:",
+		fix = "Determine what is wrong and fix this code:",
+	},
+	model = "LLM-model-here",
+}
+
+local user_config = {}
+
+function M.setup(opts)
+	user_config = vim.tbl_deep_extend("force", defaults, opts or {})
+end
+
+function M.get()
+	return user_config
+end
+
+return M

--- a/lua/ghostwrite/config.lua
+++ b/lua/ghostwrite/config.lua
@@ -3,9 +3,12 @@ local M = {}
 local defaults = {
 	default_bind_opts = { noremap = true, silent = true, nowait = true },
 	prompt_templates = {
-		summarize = "Summarize the following code:",
-		comment = "Add comments to this code:",
-		fix = "Determine what is wrong and fix this code:",
+		e = { desc = "Explain This Code", prompt = "Explain this %{language} code from %{filename}:" },
+		C = { desc = "Comment This Code", prompt = "Add comments to this %{language} code from %{filename}:" },
+		f = {
+			desc = "Fix This Code",
+			prompt = "Determine what is wrong and fix this %{language} code from %{filename}:",
+		},
 	},
 	model = "LLM-model-here",
 }

--- a/lua/ghostwrite/init.lua
+++ b/lua/ghostwrite/init.lua
@@ -1,4 +1,5 @@
 local config = require("ghostwrite.config")
+local has_which_key, which_key = pcall(require, "which-key")
 local M = {}
 
 function M.setup(opts)
@@ -39,6 +40,17 @@ function M.setup(opts)
 			desc = "Ghostwrite: Chat Panel",
 		})
 	)
+
+	-- add commands to which-key
+	if has_which_key then
+		which_key.add({
+			{ "<leader>G", group = "Ghostwrite", icon = { icon = "󰊠", color = "purple" } },
+
+			{ "<leader>Gi", cmd = "<cmd>GhostwriteInline<cr>", desc = "Inline Chat" },
+			{ "<leader>Gc", cmd = "<cmd>GhostwriteChat<cr>", desc = "Chat Panel" },
+			{ "<leader>Gr", cmd = "<cmd>ReloadGhostwrite<cr>", desc = "Reload Plugin" },
+		})
+	end
 end
 
 function _G.ReloadGhostwrite()

--- a/lua/ghostwrite/init.lua
+++ b/lua/ghostwrite/init.lua
@@ -8,24 +8,37 @@ function M.setup(opts)
 	vim.api.nvim_create_user_command("GhostwriteInline", require("ghostwrite.inline").open, {})
 	vim.api.nvim_create_user_command("GhostwriteChat", require("ghostwrite.chat").open, {})
 
+	local bind_opts = config.get().default_bind_opts
+
 	-- development command
-	vim.keymap.set("n", "<leader>Gr", "<cmd>ReloadGhostwrite<cr>", {
-		desc = "Ghostwrite: Reload plugin",
-		noremap = true,
-		silent = true,
-	})
+	vim.keymap.set(
+		"n",
+		"<leader>Gr",
+		"<cmd>ReloadGhostwrite<cr>",
+		vim.tbl_extend("force", bind_opts, {
+			desc = "Ghostwrite: Reload plugin",
+		})
+	)
+
 	-- inline chat
-	vim.keymap.set("n", "<leader>Gi", "<cmd>GhostwriteInline<cr>", {
-		desc = "Ghostwrite: Inline Chat",
-		noremap = true,
-		silent = true,
-	})
+	vim.keymap.set(
+		"n",
+		"<leader>Gi",
+		"<cmd>GhostwriteInline<cr>",
+		vim.tbl_extend("force", bind_opts, {
+			desc = "Ghostwrite: Inline Chat",
+		})
+	)
+
 	-- chat panel
-	vim.keymap.set("n", "<leader>Gc", "<cmd>GhostwriteChat<cr>", {
-		desc = "Ghostwrite: Reload plugin",
-		noremap = true,
-		silent = true,
-	})
+	vim.keymap.set(
+		"n",
+		"<leader>Gc",
+		"<cmd>GhostwriteChat<cr>",
+		vim.tbl_extend("force", bind_opts, {
+			desc = "Ghostwrite: Chat Panel",
+		})
+	)
 end
 
 function _G.ReloadGhostwrite()

--- a/lua/ghostwrite/init.lua
+++ b/lua/ghostwrite/init.lua
@@ -47,7 +47,11 @@ function M.setup(opts)
 	local function add_command_key(key)
 		for _, v in ipairs(visual_command_keys) do
 			if v == key then
-				error("ghostwrite: visual mode command key overlap, remove duplicate keys from config")
+				error(
+					"ghostwrite: visual mode command key overlap at <leader>G"
+						.. key
+						.. ". Remove or change duplicate in config."
+				)
 			end
 		end
 
@@ -55,6 +59,7 @@ function M.setup(opts)
 	end
 
 	-- open chat panel with visual selection as context
+	add_command_key("c")
 	vim.keymap.set(
 		"v",
 		"<leader>Gc",
@@ -66,9 +71,9 @@ function M.setup(opts)
 			desc = "Open In Chat Panel",
 		})
 	)
-	add_command_key("c")
 
 	-- open inline chat with visual selection as context
+	add_command_key("i")
 	vim.keymap.set(
 		"v",
 		"<leader>Gi",
@@ -80,11 +85,10 @@ function M.setup(opts)
 			desc = "Open In Inline Chat",
 		})
 	)
-	add_command_key("i")
 
 	for key, action in pairs(config.get().prompt_templates) do
-		add_command_key(key)
 		-- open inline chat with visual selection and bypass user input with a preset prompt
+		add_command_key(key)
 		vim.keymap.set(
 			"v",
 			"<leader>G" .. key,

--- a/lua/ghostwrite/init.lua
+++ b/lua/ghostwrite/init.lua
@@ -65,7 +65,8 @@ function M.setup(opts)
 		"<leader>Gc",
 		function()
 			local selection = utils.get_visual_metadata()
-			-- inline.lua call for attaching context to inline chat
+			-- TODO: set up chat context
+			-- require("ghostwrite.chat").open(selection)
 		end,
 		vim.tbl_extend("force", bind_opts, {
 			desc = "Open In Chat Panel",
@@ -78,8 +79,8 @@ function M.setup(opts)
 		"v",
 		"<leader>Gi",
 		function()
-			local selection = utils.get_visual_metadata()
-			-- inline.lua call for attaching context to inline chat
+			local selection_context = utils.get_visual_metadata()
+			require("ghostwrite.inline").get_user_input(selection_context)
 		end,
 		vim.tbl_extend("force", bind_opts, {
 			desc = "Open In Inline Chat",
@@ -94,8 +95,13 @@ function M.setup(opts)
 			"<leader>G" .. key,
 			function()
 				local selection = utils.get_visual_metadata()
-				-- inline.lua call for attaching context to inline chat
-				-- inline.lua call for sending user input
+
+				local prompt = utils.interpolate_template(action.prompt, {
+					language = selection.language,
+					filename = selection.filename,
+				})
+
+				require("ghostwrite.inline").send_user_input(prompt, selection)
 			end,
 			vim.tbl_extend("force", bind_opts, {
 				desc = "" .. action.desc,

--- a/lua/ghostwrite/init.lua
+++ b/lua/ghostwrite/init.lua
@@ -42,6 +42,18 @@ function M.setup(opts)
 		})
 	)
 
+	-- save visual command keys so we can alert if they overlap
+	local visual_command_keys = {}
+	local function add_command_key(key)
+		for _, v in ipairs(visual_command_keys) do
+			if v == key then
+				error("ghostwrite: visual mode command key overlap, remove duplicate keys from config")
+			end
+		end
+
+		table.insert(visual_command_keys, key)
+	end
+
 	-- open chat panel with visual selection as context
 	vim.keymap.set(
 		"v",
@@ -54,6 +66,7 @@ function M.setup(opts)
 			desc = "Open In Chat Panel",
 		})
 	)
+	add_command_key("c")
 
 	-- open inline chat with visual selection as context
 	vim.keymap.set(
@@ -67,8 +80,10 @@ function M.setup(opts)
 			desc = "Open In Inline Chat",
 		})
 	)
+	add_command_key("i")
 
-	local function action(key, desc, prompt)
+	for key, action in pairs(config.get().prompt_templates) do
+		add_command_key(key)
 		-- open inline chat with visual selection and bypass user input with a preset prompt
 		vim.keymap.set(
 			"v",
@@ -79,13 +94,10 @@ function M.setup(opts)
 				-- inline.lua call for sending user input
 			end,
 			vim.tbl_extend("force", bind_opts, {
-				desc = "" .. desc,
+				desc = "" .. action.desc,
 			})
 		)
 	end
-	action("f", "Fix Selected Code", "Determine what is wrong and fix this %{language} code from %{filename}:")
-	action("e", "Explain Selected Code", "Explain this %{language} code from %{filename}:")
-	action("c", "Comment Selected Code", "Add comments to this %{language} code from %{filename}:")
 
 	-- add commands to which-key
 	if has_which_key then

--- a/lua/ghostwrite/init.lua
+++ b/lua/ghostwrite/init.lua
@@ -7,7 +7,7 @@ function M.setup(opts)
 	config.setup(opts)
 
 	vim.api.nvim_create_user_command("ReloadGhostwrite", ReloadGhostwrite, {})
-	vim.api.nvim_create_user_command("GhostwriteInline", require("ghostwrite.inline").open, {})
+	vim.api.nvim_create_user_command("GhostwriteInline", require("ghostwrite.inline").get_user_input, {})
 	vim.api.nvim_create_user_command("GhostwriteChat", require("ghostwrite.chat").open, {})
 
 	local bind_opts = config.get().default_bind_opts

--- a/lua/ghostwrite/init.lua
+++ b/lua/ghostwrite/init.lua
@@ -1,22 +1,27 @@
+local config = require("ghostwrite.config")
 local M = {}
-M.default_bind_opts = { noremap = true, silent = true, nowait = true }
 
-function M.setup()
+function M.setup(opts)
+	config.setup(opts)
+
+	vim.api.nvim_create_user_command("ReloadGhostwrite", ReloadGhostwrite, {})
 	vim.api.nvim_create_user_command("GhostwriteInline", require("ghostwrite.inline").open, {})
 	vim.api.nvim_create_user_command("GhostwriteChat", require("ghostwrite.chat").open, {})
-	vim.api.nvim_create_user_command("ReloadGhostwrite", ReloadGhostwrite, {})
 
+	-- development command
+	vim.keymap.set("n", "<leader>Gr", "<cmd>ReloadGhostwrite<cr>", {
+		desc = "Ghostwrite: Reload plugin",
+		noremap = true,
+		silent = true,
+	})
+	-- inline chat
 	vim.keymap.set("n", "<leader>Gi", "<cmd>GhostwriteInline<cr>", {
 		desc = "Ghostwrite: Inline Chat",
 		noremap = true,
 		silent = true,
 	})
+	-- chat panel
 	vim.keymap.set("n", "<leader>Gc", "<cmd>GhostwriteChat<cr>", {
-		desc = "Ghostwrite: Reload plugin",
-		noremap = true,
-		silent = true,
-	})
-	vim.keymap.set("n", "<leader>Gr", "<cmd>ReloadGhostwrite<cr>", {
 		desc = "Ghostwrite: Reload plugin",
 		noremap = true,
 		silent = true,

--- a/lua/ghostwrite/init.lua
+++ b/lua/ghostwrite/init.lua
@@ -1,4 +1,5 @@
 local config = require("ghostwrite.config")
+local utils = require("ghostwrite.utils")
 local has_which_key, which_key = pcall(require, "which-key")
 local M = {}
 
@@ -41,10 +42,56 @@ function M.setup(opts)
 		})
 	)
 
+	-- open chat panel with visual selection as context
+	vim.keymap.set(
+		"v",
+		"<leader>Gc",
+		function()
+			local selection = utils.get_visual_metadata()
+			-- inline.lua call for attaching context to inline chat
+		end,
+		vim.tbl_extend("force", bind_opts, {
+			desc = "Open In Chat Panel",
+		})
+	)
+
+	-- open inline chat with visual selection as context
+	vim.keymap.set(
+		"v",
+		"<leader>Gi",
+		function()
+			local selection = utils.get_visual_metadata()
+			-- inline.lua call for attaching context to inline chat
+		end,
+		vim.tbl_extend("force", bind_opts, {
+			desc = "Open In Inline Chat",
+		})
+	)
+
+	local function action(key, desc, prompt)
+		-- open inline chat with visual selection and bypass user input with a preset prompt
+		vim.keymap.set(
+			"v",
+			"<leader>G" .. key,
+			function()
+				local selection = utils.get_visual_metadata()
+				-- inline.lua call for attaching context to inline chat
+				-- inline.lua call for sending user input
+			end,
+			vim.tbl_extend("force", bind_opts, {
+				desc = "" .. desc,
+			})
+		)
+	end
+	action("f", "Fix Selected Code", "Determine what is wrong and fix this %{language} code from %{filename}:")
+	action("e", "Explain Selected Code", "Explain this %{language} code from %{filename}:")
+	action("c", "Comment Selected Code", "Add comments to this %{language} code from %{filename}:")
+
 	-- add commands to which-key
 	if has_which_key then
 		which_key.add({
-			{ "<leader>G", group = "Ghostwrite", icon = { icon = "󰊠", color = "purple" } },
+			{ "<leader>G", group = "Ghostwrite", icon = { icon = "󰊠", color = "purple" }, mode = "n" },
+			{ "<leader>G", group = "Ghostwrite", icon = { icon = "󰊠", color = "purple" }, mode = "v" },
 
 			{ "<leader>Gi", cmd = "<cmd>GhostwriteInline<cr>", desc = "Inline Chat" },
 			{ "<leader>Gc", cmd = "<cmd>GhostwriteChat<cr>", desc = "Chat Panel" },

--- a/lua/ghostwrite/inline.lua
+++ b/lua/ghostwrite/inline.lua
@@ -14,7 +14,7 @@ function M.open()
 	local row = math.max(0, cursor_line - 3)
 
 	-- forward declare
-	local ai_response
+	local get_dummy_ai_response
 
 	local function popup(opts)
 		return {
@@ -69,7 +69,7 @@ function M.open()
 		local function send()
 			local line = vim.api.nvim_buf_get_lines(user_popup.bufnr, 0, 1, false)[1] or ""
 			user_popup:unmount()
-			ai_response(line)
+			get_dummy_ai_response(line)
 		end
 
 		user_popup:map("n", "o", ignore_key, config.default_bind_opts)
@@ -80,7 +80,7 @@ function M.open()
 
 	user_input()
 
-	ai_response = function(line)
+	get_dummy_ai_response = function(line)
 		local lines = {
 			" " .. line,
 			"󰊠 `print(data)` is displaying data",

--- a/lua/ghostwrite/inline.lua
+++ b/lua/ghostwrite/inline.lua
@@ -49,7 +49,7 @@ function M.open_inline_popup(opts)
 	})
 end
 
-function M.get_user_input()
+function M.get_user_input(context) -- optional context
 	local popup_position = M.get_popup_position()
 	local user_popup = M.open_inline_popup({
 		bottom = " [Enter] send [Esc] cancel ",
@@ -73,7 +73,7 @@ function M.get_user_input()
 	local function send()
 		local input = vim.api.nvim_buf_get_lines(user_popup.bufnr, 0, 1, false)[1] or ""
 		user_popup:unmount()
-		M.send_user_input(input)
+		M.send_user_input(input, context)
 	end
 
 	user_popup:map("n", "o", ignore_key, config.default_bind_opts)
@@ -83,6 +83,10 @@ function M.get_user_input()
 end
 
 function M.send_user_input(prompt, context)
+	if not context then
+		context = require("ghostwrite.utils").get_inline_context() -- cursor line, file, etc.
+	end
+
 	M.recieve_ai_output(prompt)
 end
 

--- a/lua/ghostwrite/inline.lua
+++ b/lua/ghostwrite/inline.lua
@@ -2,122 +2,128 @@ local config = require("ghostwrite.config").get()
 local Popup = require("nui.popup")
 local M = {}
 
-function M.open()
-	-- get the start of editor, accounts for line number section
+function M.get_popup_position()
 	local function get_text_start_col()
 		local wininfo = vim.fn.getwininfo(vim.api.nvim_get_current_win())
-		return (wininfo and wininfo[1] and wininfo[1].textoff) or 0
+		if wininfo and wininfo[1] and wininfo[1].textoff then
+			return wininfo[1].textoff
+		end
+		return 0 -- fallback when textoff is unavailable
 	end
 
 	local cursor_line = vim.fn.winline()
-	local col_offset = get_text_start_col()
-	local row = math.max(0, cursor_line - 3)
 
-	-- forward declare
-	local get_dummy_ai_response
+	return {
+		col_offset = get_text_start_col(), -- ← includes line numbers, signs, folds
+		row = math.max(0, cursor_line - 3),
+	}
+end
 
-	local function popup(opts)
-		return {
-			enter = true,
-			focusable = true,
-			border = {
-				style = "rounded",
-				text = {
-					top = " 󰊠 ghostwrite-inline ",
-					top_align = "left",
-					bottom = opts.bottom or "",
-					bottom_align = "right",
-				},
+function M.open_inline_popup(opts)
+	return Popup({
+		enter = true,
+		focusable = true,
+		border = {
+			style = "rounded",
+			text = {
+				top = " 󰊠 ghostwrite-inline ",
+				top_align = "left",
+				bottom = opts.bottom or "",
+				bottom_align = "right",
 			},
-			position = {
-				row = opts.row or 0,
-				col = opts.col or 0,
-				relative = "win",
-			},
-			size = {
-				width = opts.width or 80,
-				height = opts.height or 1,
-			},
-			buf_options = {
-				modifiable = true,
-				readonly = false,
-				bufhidden = "wipe",
-			},
-		}
+		},
+		position = {
+			row = opts.row or 0,
+			col = opts.col or 0,
+			relative = "win",
+		},
+		size = {
+			width = opts.width or 80,
+			height = opts.height or 1,
+		},
+		buf_options = {
+			modifiable = true,
+			readonly = false,
+			bufhidden = "wipe",
+		},
+	})
+end
+
+function M.get_user_input()
+	local popup_position = M.get_popup_position()
+	local user_popup = M.open_inline_popup({
+		bottom = " [Enter] send [Esc] cancel ",
+		row = popup_position.row,
+		col = popup_position.col_offset,
+		height = 1,
+	})
+	user_popup:mount()
+
+	-- enter in insert mode
+	vim.schedule(function()
+		vim.cmd("startinsert")
+	end)
+
+	local function ignore_key() end
+
+	local function close()
+		user_popup:unmount()
 	end
 
-	local function user_input()
-		local user_popup = Popup(popup({
-			bottom = " [Enter] send [Esc] cancel ",
-			row = row,
-			col = col_offset,
-			height = 1,
-		}))
-		user_popup:mount()
-
-		-- enter in insert mode
-		vim.schedule(function()
-			vim.cmd("startinsert")
-		end)
-
-		local function ignore_key() end
-
-		local function close()
-			user_popup:unmount()
-		end
-
-		local function send()
-			local line = vim.api.nvim_buf_get_lines(user_popup.bufnr, 0, 1, false)[1] or ""
-			user_popup:unmount()
-			get_dummy_ai_response(line)
-		end
-
-		user_popup:map("n", "o", ignore_key, config.default_bind_opts)
-		user_popup:map("n", "O", ignore_key, config.default_bind_opts)
-		user_popup:map("n", "<Esc>", close, config.default_bind_opts)
-		user_popup:map("i", "<CR>", send, config.default_bind_opts)
+	local function send()
+		local input = vim.api.nvim_buf_get_lines(user_popup.bufnr, 0, 1, false)[1] or ""
+		user_popup:unmount()
+		M.send_user_input(input)
 	end
 
-	user_input()
+	user_popup:map("n", "o", ignore_key, config.default_bind_opts)
+	user_popup:map("n", "O", ignore_key, config.default_bind_opts)
+	user_popup:map("n", "<Esc>", close, config.default_bind_opts)
+	user_popup:map("i", "<CR>", send, config.default_bind_opts)
+end
 
-	get_dummy_ai_response = function(line)
-		local lines = {
-			" " .. line,
-			"󰊠 `print(data)` is displaying data",
-		}
-		local count = #lines
+function M.send_user_input(prompt, context)
+	M.recieve_ai_output(prompt)
+end
 
-		local response_popup = Popup(popup({
-			bottom = " [y] apply  [n] dismiss  [→] move to chat ",
-			row = row - count + 1,
-			col = col_offset,
-			height = count,
-		}))
-		response_popup:mount()
+function M.recieve_ai_output(prompt)
+	local lines = {
+		" " .. prompt,
+		"󰊠 `print(data)` is displaying data",
+	}
+	local count = #lines
 
-		-- write response into popup
-		vim.bo[response_popup.bufnr].modifiable = true
-		vim.api.nvim_buf_set_lines(response_popup.bufnr, 0, -1, false, lines)
-		vim.bo[response_popup.bufnr].modifiable = false
+	local popup_position = M.get_popup_position()
+	local response_popup = M.open_inline_popup({
+		bottom = " [y] apply  [n] dismiss  [→] move to chat ",
+		row = popup_position.row - count + 1,
+		col = popup_position.col_offset,
+		height = count,
+	})
+	response_popup:mount()
 
-		-- enter in normal mode
-		vim.defer_fn(function()
-			vim.cmd("stopinsert")
-		end, 10) -- delay by 10ms
+	-- write response into popup
+	vim.bo[response_popup.bufnr].modifiable = true
+	vim.api.nvim_buf_set_lines(response_popup.bufnr, 0, -1, false, lines)
+	vim.bo[response_popup.bufnr].modifiable = false
 
-		local function apply()
-			print("eventually ghostwrite will apply those suggestions")
-			response_popup:unmount()
-		end
+	-- enter in normal mode
+	vim.defer_fn(function()
+		vim.cmd("stopinsert")
+	end, 10) -- delay by 10ms
 
-		local function dismiss()
-			response_popup:unmount()
-		end
-
-		response_popup:map("n", "y", apply, config.default_bind_opts)
-		response_popup:map("n", "n", dismiss, config.default_bind_opts)
-		response_popup:map("n", "<Esc>", dismiss, config.default_bind_opts)
+	local function apply()
+		print("eventually ghostwrite will apply those suggestions")
+		response_popup:unmount()
 	end
+
+	local function dismiss()
+		response_popup:unmount()
+	end
+
+	response_popup:map("n", "y", apply, config.default_bind_opts)
+	response_popup:map("n", "n", dismiss, config.default_bind_opts)
+	response_popup:map("n", "<Esc>", dismiss, config.default_bind_opts)
 end
 
 return M

--- a/lua/ghostwrite/inline.lua
+++ b/lua/ghostwrite/inline.lua
@@ -1,3 +1,4 @@
+local config = require("ghostwrite.config").get()
 local Popup = require("nui.popup")
 local M = {}
 
@@ -71,10 +72,10 @@ function M.open()
 			ai_response(line)
 		end
 
-		user_popup:map("n", "o", ignore_key, M.default_bind_opts)
-		user_popup:map("n", "O", ignore_key, M.default_bind_opts)
-		user_popup:map("n", "<Esc>", close, M.default_bind_opts)
-		user_popup:map("i", "<CR>", send, M.default_bind_opts)
+		user_popup:map("n", "o", ignore_key, config.default_bind_opts)
+		user_popup:map("n", "O", ignore_key, config.default_bind_opts)
+		user_popup:map("n", "<Esc>", close, config.default_bind_opts)
+		user_popup:map("i", "<CR>", send, config.default_bind_opts)
 	end
 
 	user_input()
@@ -113,9 +114,9 @@ function M.open()
 			response_popup:unmount()
 		end
 
-		response_popup:map("n", "y", apply, M.default_bind_opts)
-		response_popup:map("n", "n", dismiss, M.default_bind_opts)
-		response_popup:map("n", "<Esc>", dismiss, M.default_bind_opts)
+		response_popup:map("n", "y", apply, config.default_bind_opts)
+		response_popup:map("n", "n", dismiss, config.default_bind_opts)
+		response_popup:map("n", "<Esc>", dismiss, config.default_bind_opts)
 	end
 end
 

--- a/lua/ghostwrite/utils.lua
+++ b/lua/ghostwrite/utils.lua
@@ -1,0 +1,19 @@
+local M = {}
+
+--- Extract metadata about the current visual selection to send as context to the backend.
+-- @return table containing file path, start/end positions, and selection mode
+function M.get_visual_metadata()
+	local start_pos = vim.fn.getpos("'<")
+	local end_pos = vim.fn.getpos("'>")
+	local mode = vim.fn.visualmode() -- char, line, or block
+	local filepath = vim.fn.expand("%:p")
+
+	return {
+		file = filepath,
+		start = { line = start_pos[2], col = start_pos[3] },
+		["end"] = { line = end_pos[2], col = end_pos[3] },
+		mode = mode,
+	}
+end
+
+return M

--- a/lua/ghostwrite/utils.lua
+++ b/lua/ghostwrite/utils.lua
@@ -1,19 +1,66 @@
 local M = {}
 
+--- Interpolate %{var} placeholders in a template string
+-- @param template string The string with %{placeholders}
+-- @param vars table A table of key-value pairs to fill in
+-- @return string
+function M.interpolate_template(template, vars)
+	return (template:gsub("%%{(.-)}", function(key)
+		return vars[key] or ""
+	end))
+end
+
 --- Extract metadata about the current visual selection to send as context to the backend.
--- @return table containing file path, start/end positions, and selection mode
+-- @return table containing file path, file name, language, range (start/end positions), and optionally buffer content
 function M.get_visual_metadata()
 	local start_pos = vim.fn.getpos("'<")
 	local end_pos = vim.fn.getpos("'>")
-	local mode = vim.fn.visualmode() -- char, line, or block
-	local filepath = vim.fn.expand("%:p")
 
-	return {
-		file = filepath,
-		start = { line = start_pos[2], col = start_pos[3] },
-		["end"] = { line = end_pos[2], col = end_pos[3] },
-		mode = mode,
+	local file = vim.fn.expand("%:p")
+	local filename = vim.fn.fnamemodify(file, ":t")
+	local language = vim.filetype.match({ filename = file }) or vim.bo.filetype
+
+	local context = {
+		file = file,
+		filename = filename,
+		language = language,
+		range = {
+			start = { line = start_pos[2], col = start_pos[3] },
+			["end"] = { line = end_pos[2], col = end_pos[3] },
+		},
 	}
+
+	-- if buffer has unsaved changes, include full buffer content
+	if vim.bo.modified then
+		context.buffer = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+	end
+
+	return context
+end
+
+--- Extract context from the current cursor position for inline prompts.
+-- @return table containing file path, file name, language, range, and optionally buffer content
+function M.get_inline_context()
+	local file = vim.fn.expand("%:p")
+	local filename = vim.fn.fnamemodify(file, ":t")
+	local line = vim.api.nvim_win_get_cursor(0)[1]
+	local language = vim.filetype.match({ filename = file }) or vim.bo.filetype
+
+	local context = {
+		file = file,
+		filename = filename,
+		language = language,
+		range = {
+			start = { line = line, col = 1 },
+			["end"] = { line = line, col = -1 }, -- single line
+		},
+	}
+
+	if vim.bo.modified then
+		context.buffer = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+	end
+
+	return context
 end
 
 return M


### PR DESCRIPTION
Implements the UI and keybindings for visual selection commands.

- Moves default_bind_opts into the config for user customization
- Adds which-key command labels for improved UX
- Adds get_visual_metadata() for collecting file, range, and language context
- Dynamically registers visual mode command keymaps from prompt_templates in config
- Supports default actions: explain, comment, fix, and open in chat panel
- Refactors inline module to support bypassing user input with preset prompts
- Sends visual selection + preset prompt to inline chat via send_user_input()
- Passes full buffer to backend if the file is unsaved
- Future-ready for user-defined prompt templates and custom visual actions

Closes #1